### PR TITLE
Fix issue #1 the apparent hang in writing the trajectories

### DIFF
--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -65,6 +65,7 @@ public sum_mass,sum_heat,bilin,yearday,bergs_chksum
 public checksum_gridded
 public grd_chksum2,grd_chksum3
 public fix_restart_dates, offset_berg_dates
+public reverse_list
 
 type :: icebergs_gridded
   type(domain2D), pointer :: domain ! MPP domain
@@ -1201,7 +1202,9 @@ end subroutine send_bergs_to_other_pes
     traj%cn=buff%data(22,n)
     traj%hi=buff%data(23,n)
 
-    call append_posn(first, traj) 
+!    call append_posn(first, traj) !This call could take a very long time (as if the run hangs) if there are millions of nodes in the list. Use push_posn instead and reverse the list later before writing the file.
+! 
+    call push_posn(first, traj) 
 
   end subroutine unpack_traj_from_buffer2
 
@@ -1622,6 +1625,30 @@ type(iceberg), pointer :: this
 end subroutine record_posn
 
 ! ##############################################################################
+
+subroutine reverse_list(list)
+  ! Arguments
+  type(xyt), pointer :: list
+  
+  ! Local variables
+  type(xyt), pointer :: head,tail,node
+  integer :: i
+
+  i=0
+  head=>list
+  tail=>list
+  node=>list%next
+  list%next=>null()
+  do while (associated(node))  
+     head=>node
+     node=>node%next
+     head%next=>tail
+     tail=>head
+     i=i+1
+  enddo
+  list=>head
+  print*,'reverse_list number of nodes= ',i
+end subroutine reverse_list
 
 subroutine push_posn(trajectory, posn_vals)
 ! Arguments

--- a/icebergs_io.F90
+++ b/icebergs_io.F90
@@ -22,6 +22,7 @@ use ice_bergs_framework, only: icebergs_gridded, xyt, iceberg, icebergs, buffer
 use ice_bergs_framework, only: pack_berg_into_buffer2,unpack_berg_from_buffer2
 use ice_bergs_framework, only: pack_traj_into_buffer2,unpack_traj_from_buffer2
 use ice_bergs_framework, only: find_cell,find_cell_by_search,count_bergs,is_point_in_cell,pos_within_cell,append_posn
+use ice_bergs_framework, only: push_posn
 use ice_bergs_framework, only: add_new_berg_to_list,destroy_iceberg
 use ice_bergs_framework, only: increase_ibuffer,increase_ibuffer_traj,grd_chksum2,grd_chksum3
 use ice_bergs_framework, only: sum_mass,sum_heat,bilin
@@ -29,7 +30,7 @@ use ice_bergs_framework, only: sum_mass,sum_heat,bilin
 use ice_bergs_framework, only: nclasses, buffer_width, buffer_width_traj
 use ice_bergs_framework, only: verbose, really_debug, debug, restart_input_dir,make_calving_reproduce
 use ice_bergs_framework, only: ignore_ij_restart, use_slow_find,generate_test_icebergs,print_berg
-
+use ice_bergs_framework, only: reverse_list
 
 implicit none ; private
 
@@ -844,7 +845,7 @@ type(buffer), pointer :: obuffer_io=>null(), ibuffer_io=>null()
      if(associated(trajectory)) then
         this=>trajectory
         do while (associated(this))
-           call append_posn(traj4io, this)
+           call push_posn(traj4io, this)
            this=>this%next
         enddo
      endif
@@ -853,6 +854,7 @@ type(buffer), pointer :: obuffer_io=>null(), ibuffer_io=>null()
   !Now gather and append the bergs from all pes in the io_tile to the list on corresponding io_tile_root_pe
   ntrajs_sent_io =0
   ntrajs_rcvd_io =0 
+
 
   if(is_io_tile_root_pe) then
      !Receive trajs from all pes in this I/O tile !FRAGILE!SCARY!
@@ -867,6 +869,7 @@ type(buffer), pointer :: obuffer_io=>null(), ibuffer_io=>null()
            enddo
        endif
      enddo
+     call reverse_list(traj4io)
   else
      !Pack and Send trajs to the root pe for this I/O tile
      if (associated(trajectory)) then


### PR DESCRIPTION
- Fixes issue #1
- @sternalon reported and I verified that 1 year model run apparently hangs at the end when trying to write icebergs trajectories
-  This turned out not to be an i/o issue but due to the root pe (or io_tile_root_pes) traversing
  a linked list of millions of nodes. It just take a long long time and the model times out.
- This fix "push"es the nodes at the top of the list instead of traversing it and trying to find the tail to append.
  -The list will be in reverse order and has to be reversed before writing to file.
