### PR TITLE
Iceberg identifications

### DIFF
--- a/icebergs.F90
+++ b/icebergs.F90
@@ -582,7 +582,7 @@ endif
     write(stderrunit,200) mpp_pe(),'Starting pars:', &
       'yr0=',berg%start_year, 'day0=',berg%start_day, &
       'lon0=',berg%start_lon, 'lat0=',berg%start_lat, 'mass0=',berg%start_mass, &
-      'sclng=',berg%mass_scaling
+      'sclng=',berg%mass_scaling, 'num0=',berg%iceberg_num
     write(stderrunit,100) mpp_pe(),'Geometry:', &
       'M=',M, 'T=',T, 'D=',D, 'F=',F, 'W=',W, 'L=',L
     write(stderrunit,100) mpp_pe(),'delta U:', &
@@ -1770,6 +1770,7 @@ integer :: stderrunit
           newberg%start_lon=newberg%lon
           newberg%start_lat=newberg%lat
           newberg%start_year=bergs%current_year
+          newberg%iceberg_num=bergs%current_year !!!! ALon: MP: Change this!!
           newberg%start_day=bergs%current_yearday+ddt/86400.
           newberg%start_mass=bergs%initial_mass(k)
           newberg%mass_scaling=bergs%mass_scaling(k)
@@ -1789,6 +1790,7 @@ integer :: stderrunit
           icnt=icnt+1
           bergs%nbergs_calved=bergs%nbergs_calved+1
           bergs%nbergs_calved_by_class(k)=bergs%nbergs_calved_by_class(k)+1
+          grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         enddo
         icntmax=max(icntmax,icnt)
       enddo

--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -72,6 +72,7 @@ type :: icebergs_gridded
   integer :: halo ! Nominal halo width
   integer :: isc, iec, jsc, jec ! Indices of computational domain
   integer :: isd, ied, jsd, jed ! Indices of data domain
+  integer :: isg, ieg, jsg, jeg ! Indices of global domain
   integer :: my_pe, pe_N, pe_S, pe_E, pe_W ! MPI PE identifiers
   real, dimension(:,:), pointer :: lon=>null() ! Longitude of cell corners
   real, dimension(:,:), pointer :: lat=>null() ! Latitude of cell corners
@@ -236,7 +237,7 @@ subroutine ice_bergs_framework_init(bergs, &
 
 use mpp_parameter_mod, only: SCALAR_PAIR, CGRID_NE, BGRID_NE, CORNER, AGRID
 use mpp_domains_mod, only: mpp_update_domains, mpp_define_domains
-use mpp_domains_mod, only: mpp_get_compute_domain, mpp_get_data_domain
+use mpp_domains_mod, only: mpp_get_compute_domain, mpp_get_data_domain, mpp_get_global_domain
 use mpp_domains_mod, only: CYCLIC_GLOBAL_DOMAIN, FOLD_NORTH_EDGE
 use mpp_domains_mod, only: mpp_get_neighbor_pe, NORTH, SOUTH, EAST, WEST
 use mpp_domains_mod, only: mpp_define_io_domain
@@ -362,11 +363,13 @@ real :: Total_mass  !Added by Alon
  !write(stderrunit,*) 'diamond: get compute domain'
   call mpp_get_compute_domain( grd%domain, grd%isc, grd%iec, grd%jsc, grd%jec )
   call mpp_get_data_domain( grd%domain, grd%isd, grd%ied, grd%jsd, grd%jed )
+  call mpp_get_global_domain( grd%domain, grd%isg, grd%ieg, grd%jsg, grd%jeg )
 
   call mpp_get_neighbor_pe(grd%domain, NORTH, grd%pe_N)
   call mpp_get_neighbor_pe(grd%domain, SOUTH, grd%pe_S)
   call mpp_get_neighbor_pe(grd%domain, EAST, grd%pe_E)
   call mpp_get_neighbor_pe(grd%domain, WEST, grd%pe_W)
+
 
   folded_north_on_pe = ((dom_y_flags == FOLD_NORTH_EDGE) .and. (grd%jec == gnj)) 
  !write(stderrunit,'(a,6i4)') 'diamonds, icebergs_init: pe,n,s,e,w =',mpp_pe(),grd%pe_N,grd%pe_S,grd%pe_E,grd%pe_W, NULL_PE
@@ -662,6 +665,10 @@ endif
  !write(stderrunit,*) 'diamonds: done'
   call mpp_clock_end(bergs%clock_ini)
   call mpp_clock_end(bergs%clock)
+
+!print *, mpp_pe(), 'Alon: global', grd%isg, grd%ieg, grd%jsg, grd%jeg
+!print *, mpp_pe(), 'Alon: comp', grd%isc, grd%iec, grd%jsc, grd%jec
+!print *, mpp_pe(), 'Alon: data', grd%isd, grd%ied, grd%jsd, grd%jed
 
 end subroutine ice_bergs_framework_init
 
@@ -1577,6 +1584,7 @@ integer :: stderrunit
   berg%next=>null()
 
 end subroutine create_iceberg
+
 
 ! ##############################################################################
 

--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -16,7 +16,7 @@ use time_manager_mod, only: time_type, get_date, get_time, set_date, operator(-)
 implicit none ; private
 
 integer, parameter :: buffer_width=29 !Changed from 20 to 29 by Alon 
-integer, parameter :: buffer_width_traj=31  !Changed from 23 by Alon
+integer, parameter :: buffer_width_traj=32  !Changed from 23 by Alon
 integer, parameter :: nclasses=10 ! Number of ice bergs classes
 
 !Local Vars
@@ -424,7 +424,7 @@ real :: Total_mass  !Added by Alon
   allocate( bergs%nbergs_calved_by_class(nclasses) ); bergs%nbergs_calved_by_class(:)=0
   allocate( grd%parity_x(grd%isd:grd%ied, grd%jsd:grd%jed) ); grd%parity_x(:,:)=1.
   allocate( grd%parity_y(grd%isd:grd%ied, grd%jsd:grd%jed) ); grd%parity_y(:,:)=1.
-  allocate( grd%iceberg_counter_grd(grd%isd:grd%ied, grd%jsd:grd%jed) ); grd%iceberg_counter_grd(:,:)=0
+  allocate( grd%iceberg_counter_grd(grd%isd:grd%ied, grd%jsd:grd%jed) ); grd%iceberg_counter_grd(:,:)=1
 
  !write(stderrunit,*) 'diamonds: copying grid'
   ! Copy data declared on ice model computational domain
@@ -1248,6 +1248,7 @@ end subroutine send_bergs_to_other_pes
     buff%data(29,n)=traj%vvel_old !Alon
     buff%data(30,n)=traj%lon_old !Alon
     buff%data(31,n)=traj%lat_old !Alon
+    buff%data(32,n)=float(traj%iceberg_num)
 
   end subroutine pack_traj_into_buffer2
 
@@ -1293,6 +1294,7 @@ end subroutine send_bergs_to_other_pes
     traj%vvel_old=buff%data(29,n) !Alon
     traj%lon_old=buff%data(30,n) !Alon
     traj%lat_old=buff%data(31,n) !Alon
+    traj%iceberg_num=nint(buff%data(32,n))
 
     call append_posn(first, traj)
 

--- a/icebergs_io.F90
+++ b/icebergs_io.F90
@@ -529,11 +529,14 @@ contains
   type(time_type), intent(in) :: Time
   ! Local variables
   integer :: i,j
+  integer :: iNg, jNg  !Total number of points gloablly in i and j direction
   type(iceberg) :: localberg ! NOT a pointer but an actual local variable
   integer :: iyr, imon, iday, ihr, imin, isec
 
     ! For convenience
     grd=>bergs%grd
+    iNg=(grd%ieg-grd%isg+1) ! Total number of points globally in i direction
+    jNg=(grd%jeg-grd%jsg+1) ! Total number of points globally in j direction
 
     call get_date(Time, iyr, imon, iday, ihr, imin, isec)
 
@@ -554,7 +557,6 @@ contains
         localberg%start_lon=localberg%lon
         localberg%start_lat=localberg%lat
         localberg%start_year=iyr
-        localberg%iceberg_num=iyr   !MP1!!!!Insert complex formulae here! Alon
         localberg%start_day=float(iday)+(float(ihr)+float(imin)/60.)/24.
         localberg%start_mass=localberg%mass
         localberg%mass_scaling=bergs%mass_scaling(1)
@@ -568,6 +570,8 @@ contains
         localberg%vvel_old=0. !Alon
         localberg%bxn=0. !Alon
         localberg%byn=0. !Alon
+        localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
+        grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
         localberg%uvel=-1.
         localberg%vvel=0.
@@ -577,6 +581,8 @@ contains
         localberg%vvel_old=0. !Alon
         localberg%bxn=0. !Alon
         localberg%byn=0. !Alon
+        localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
+        grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
         localberg%uvel=0.
         localberg%vvel=1.
@@ -586,6 +592,8 @@ contains
         localberg%vvel_old=0. !Alon
         localberg%bxn=0. !Alon
         localberg%byn=0. !Alon
+        localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
+        grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
         localberg%uvel=0.
         localberg%vvel=-1.
@@ -595,6 +603,8 @@ contains
         localberg%vvel_old=0. !Alon
         localberg%bxn=0. !Alon
         localberg%byn=0. !Alon
+        localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
+        grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
       endif
     enddo; enddo
@@ -653,7 +663,7 @@ integer, allocatable, dimension(:) :: ine,       &
                                       iceberg_num,       &
                                       start_year
 
-!integer, allocatable, dimension(:,:) :: iceberg_counter_gre
+!integer, allocatable, dimension(:,:) :: iceberg_counter_grd
 
   ! Get the stderr unit number
   stderrunit=stderr()
@@ -844,11 +854,14 @@ contains
   type(time_type), intent(in) :: Time
   ! Local variables
   integer :: i,j
+  integer :: iNg, jNg  !Total number of points gloablly in i and j direction
   type(iceberg) :: localberg ! NOT a pointer but an actual local variable
   integer :: iyr, imon, iday, ihr, imin, isec
 
     ! For convenience
     grd=>bergs%grd
+    iNg=(grd%ieg-grd%isg+1) ! Total number of points globally in i direction
+    jNg=(grd%jeg-grd%jsg+1) ! Total number of points globally in j direction
 
     call get_date(Time, iyr, imon, iday, ihr, imin, isec)
 
@@ -869,7 +882,6 @@ contains
         localberg%start_lon=localberg%lon
         localberg%start_lat=localberg%lat
         localberg%start_year=iyr
-        localberg%iceberg_num=iyr !Alon: MP2: insert complex formulae here!!
         localberg%start_day=float(iday)+(float(ihr)+float(imin)/60.)/24.
         localberg%start_mass=localberg%mass
         localberg%mass_scaling=bergs%mass_scaling(1)
@@ -883,6 +895,8 @@ contains
         localberg%vvel_old=0. !Alon
         localberg%bxn=0. !Alon
         localberg%byn=0. !Alon
+        localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
+        grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
         localberg%uvel=-1.
         localberg%vvel=0.
@@ -892,6 +906,8 @@ contains
         localberg%vvel_old=0. !Alon
         localberg%bxn=0. !Alon
         localberg%byn=0. !Alon
+        localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
+        grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
         localberg%uvel=0.
         localberg%vvel=1.
@@ -901,6 +917,8 @@ contains
         localberg%vvel_old=0. !Alon
         localberg%bxn=0. !Alon
         localberg%byn=0. !Alon
+        localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
+        grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
         localberg%uvel=0.
         localberg%vvel=-1.
@@ -910,6 +928,8 @@ contains
         localberg%vvel_old=0. !Alon
         localberg%bxn=0. !Alon
         localberg%byn=0. !Alon
+        localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
+        grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
       endif
     enddo; enddo
@@ -948,14 +968,18 @@ type(randomNumberStream) :: rns
       if (verbose.and.mpp_pe().eq.mpp_root_pe()) write(*,'(a)') &
        'diamonds, read_restart_calving: reading stored_heat from restart file.'
       call read_data(filename, 'stored_heat', grd%stored_heat, grd%domain)
-                if (field_exist(filename, 'iceberg_counting_grd')) then
-                        print *, 'field exitst!!!'
-                    !call read_data(filename, 'iceberg_counting_grd', grd%iceberg_counting_grd, grd%domain) ! - why does this not work???
-                endif
     else
       if (verbose.and.mpp_pe().eq.mpp_root_pe()) write(*,'(a)') &
      'diamonds, read_restart_calving: stored_heat WAS NOT FOUND in the file. Setting to 0.'
       grd%stored_heat(:,:)=0.
+    endif
+    if (field_exist(filename, 'iceberg_counter_grd')) then
+      if (verbose.and.mpp_pe().eq.mpp_root_pe()) write(*,'(a)') &
+       'diamonds, read_restart_calving: reading iceberg_counter_grd from restart file.'
+      call read_data(filename, 'iceberg_counter_grd', grd%iceberg_counter_grd, grd%domain) 
+    else
+      if (verbose.and.mpp_pe().eq.mpp_root_pe()) write(*,'(a)') &
+     'diamonds, read_restart_calving: iceberg_counter_grd WAS NOT FOUND in the file. Setting to 0.'
       grd%iceberg_counter_grd(:,:)=0
     endif
     bergs%restarted=.true.

--- a/icebergs_io.F90
+++ b/icebergs_io.F90
@@ -224,7 +224,7 @@ integer, allocatable, dimension(:) :: ine,       &
   id = register_restart_field(bergs_restart,filename,'start_year',start_year, &
                                             longname='calendar year of calving event', units='years')
   id = register_restart_field(bergs_restart,filename,'iceberg_num',iceberg_num, &
-                                            longname='identification of the iceberg', units='years')
+                                            longname='identification of the iceberg', units='dimensionless')
   id = register_restart_field(bergs_restart,filename,'start_day',start_day, &
                                             longname='year day of calving event',units='days')
   id = register_restart_field(bergs_restart,filename,'start_mass',start_mass, &
@@ -1030,7 +1030,7 @@ subroutine write_trajectory(trajectory)
 type(xyt), pointer :: trajectory
 ! Local variables
 integer :: iret, ncid, i_dim, i
-integer :: lonid, latid, yearid, dayid, uvelid, vvelid
+integer :: lonid, latid, yearid, dayid, uvelid, vvelid, iceberg_numid
 !integer :: axnid, aynid, uvel_oldid, vvel_oldid, lat_oldid, lon_oldid, bxnid, bynid !Added by Alon 
 integer :: uoid, void, uiid, viid, uaid, vaid, sshxid, sshyid, sstid
 integer :: cnid, hiid
@@ -1170,6 +1170,7 @@ logical :: io_is_in_append_mode
       sstid = inq_varid(ncid, 'sst')
       cnid = inq_varid(ncid, 'cn')
       hiid = inq_varid(ncid, 'hi')
+      iceberg_numid = inq_varid(ncid, 'iceberg_num')
     else
       ! Dimensions
       iret = nf_def_dim(ncid, 'i', NF_UNLIMITED, i_dim)
@@ -1199,6 +1200,7 @@ logical :: io_is_in_append_mode
       sstid = def_var(ncid, 'sst', NF_DOUBLE, i_dim)
       cnid = def_var(ncid, 'cn', NF_DOUBLE, i_dim)
       hiid = def_var(ncid, 'hi', NF_DOUBLE, i_dim)
+      iceberg_numid = def_var(ncid, 'iceberg_num', NF_INT, i_dim)
 
       ! Attributes
       iret = nf_put_att_int(ncid, NCGLOBAL, 'file_format_major_version', NF_INT, 1, 0)
@@ -1249,6 +1251,8 @@ logical :: io_is_in_append_mode
       call put_att(ncid, cnid, 'units', 'none')
       call put_att(ncid, hiid, 'long_name', 'sea ice thickness')
       call put_att(ncid, hiid, 'units', 'm')
+      call put_att(ncid, iceberg_numid, 'long_name', 'iceberg id number')
+      call put_att(ncid, iceberg_numid, 'units', 'dimensionless')
     endif
 
     ! End define mode
@@ -1286,6 +1290,7 @@ logical :: io_is_in_append_mode
       call put_double(ncid, sstid, i, this%sst)
       call put_double(ncid, cnid, i, this%cn)
       call put_double(ncid, hiid, i, this%hi)
+      call put_int(ncid, iceberg_numid, i, this%iceberg_num)
       next=>this%next
       deallocate(this)
       this=>next


### PR DESCRIPTION
I have added a number scheme so that each iceberg gets a unique number. The number is based on a counter which counts how many icebergs have been created in a particular grid cell. 

The iceberg number is called iceberg_num, and is written to the iceberg_trajectory file, to be used in post processing. It is also written and read from the iceberg.res restart file.

The iceberg grd counter is called iceberg_counter_grd. It is written and read from the calving.res restart file (since it is gridded).

The previous method used for identifying icebergs (ie: start_year, start_mass, start_lon, start_lat, start_day) has been left in place, and is still being used in several places to sort icebergs. This can be removed and replaced by the counter system at a later time.
