### PR TITLE
Lists and bonds

### DIFF
--- a/icebergs.F90
+++ b/icebergs.F90
@@ -1780,6 +1780,7 @@ integer :: stderrunit
           newberg%start_mass=bergs%initial_mass(k)
           newberg%mass_scaling=bergs%mass_scaling(k)
           newberg%mass_of_bits=0.
+          newberg%halo_berg=0.
           newberg%heat_density=grd%stored_heat(i,j)/grd%stored_ice(i,j,k) ! This is in J/kg
           call add_new_berg_to_list(bergs%list(i,j)%first, newberg)
           calved_to_berg=bergs%initial_mass(k)*bergs%mass_scaling(k) ! Units of kg

--- a/icebergs.F90
+++ b/icebergs.F90
@@ -30,7 +30,7 @@ use ice_bergs_framework, only: nclasses,old_bug_bilin
 use ice_bergs_framework, only: sum_mass,sum_heat,bilin,yearday,count_bergs,bergs_chksum
 use ice_bergs_framework, only: checksum_gridded,add_new_berg_to_list
 use ice_bergs_framework, only: send_bergs_to_other_pes,move_trajectory,move_all_trajectories
-use ice_bergs_framework, only: move_berg_between_cells, update_halo
+use ice_bergs_framework, only: move_berg_between_cells, update_halo_icebergs
 use ice_bergs_framework, only: record_posn,check_position,print_berg,print_bergs,print_fld
 use ice_bergs_framework, only: add_new_berg_to_list,delete_iceberg_from_list,destroy_iceberg
 use ice_bergs_framework, only: grd_chksum2,grd_chksum3
@@ -1276,7 +1276,7 @@ integer :: stderrunit
   ! Send bergs to other PEs
   call mpp_clock_begin(bergs%clock_com)
   call send_bergs_to_other_pes(bergs)
-  call update_halo(bergs)
+  call update_halo_icebergs(bergs)
   if (debug) call bergs_chksum(bergs, 'run bergs (exchanged)')
   if (debug) call checksum_gridded(bergs%grd, 's/r run after exchange')
   call mpp_clock_end(bergs%clock_com)

--- a/icebergs.F90
+++ b/icebergs.F90
@@ -165,11 +165,10 @@ R1=sqrt(A1/pi) ! Interaction radius of the iceberg (assuming circular icebergs)
 lon1=berg%lon; lat1=berg%lat
 call rotpos_to_tang(lon1,lat1,x1,y1)
 
-  do grdj = bergs%grd%jsc,bergs%grd%jec ; do grdi = bergs%grd%isc,bergs%grd%iec
+  do grdj = berg%jne-1,berg%jne+1 ; do grdi = berg%ine-1,berg%ine+1
   other_berg=>bergs%list(grdi,grdj)%first
 
 !Note: This summing should be made order invarient. 
-!Note: Need to limit how many icebergs we search over
   do while (associated(other_berg)) ! loop over all other bergs  
        L2=other_berg%length
        W2=other_berg%width

--- a/icebergs.F90
+++ b/icebergs.F90
@@ -167,7 +167,6 @@ call rotpos_to_tang(lon1,lat1,x1,y1)
 
   do grdj = berg%jne-1,berg%jne+1 ; do grdi = berg%ine-1,berg%ine+1
   other_berg=>bergs%list(grdi,grdj)%first
-
 !Note: This summing should be made order invarient. 
   do while (associated(other_berg)) ! loop over all other bergs  
        L2=other_berg%length
@@ -342,7 +341,6 @@ C_N=1.0
 beta=1.0
 use_new_predictive_corrective=.True.
 endif
-
 
 !print *, 'axn=',axn,'ayn=',ayn
   u_star=uvel0+(axn*(dt/2.))  !Alon

--- a/icebergs.F90
+++ b/icebergs.F90
@@ -30,7 +30,7 @@ use ice_bergs_framework, only: nclasses,old_bug_bilin
 use ice_bergs_framework, only: sum_mass,sum_heat,bilin,yearday,count_bergs,bergs_chksum
 use ice_bergs_framework, only: checksum_gridded,add_new_berg_to_list
 use ice_bergs_framework, only: send_bergs_to_other_pes,move_trajectory,move_all_trajectories
-use ice_bergs_framework, only: move_berg_between_cells
+use ice_bergs_framework, only: move_berg_between_cells, update_halo
 use ice_bergs_framework, only: record_posn,check_position,print_berg,print_bergs,print_fld
 use ice_bergs_framework, only: add_new_berg_to_list,delete_iceberg_from_list,destroy_iceberg
 use ice_bergs_framework, only: grd_chksum2,grd_chksum3
@@ -1278,6 +1278,7 @@ integer :: stderrunit
   ! Send bergs to other PEs
   call mpp_clock_begin(bergs%clock_com)
   call send_bergs_to_other_pes(bergs)
+  call update_halo(bergs)
   if (debug) call bergs_chksum(bergs, 'run bergs (exchanged)')
   if (debug) call checksum_gridded(bergs%grd, 's/r run after exchange')
   call mpp_clock_end(bergs%clock_com)

--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -543,6 +543,9 @@ if (iceberg_halo .gt. halo) then
     iceberg_halo=halo
 endif
 
+if (Runge_not_Verlet) then
+  interactive_icebergs_on=.false.  ! Iceberg interactions only with Verlet
+endif
 
  ! Parameters
   bergs%dt=dt

--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -54,7 +54,7 @@ public icebergs_gridded, xyt, iceberg, icebergs, buffer
 !Public subs
 public ice_bergs_framework_init
 public send_bergs_to_other_pes
-public update_halo
+public update_halo_icebergs
 public pack_berg_into_buffer2, unpack_berg_from_buffer2
 public pack_traj_into_buffer2, unpack_traj_from_buffer2
 public increase_buffer, increase_ibuffer, increase_ibuffer_traj, increase_buffer_traj
@@ -770,7 +770,7 @@ end subroutine move_berg_between_cells
 
 ! #############################################################################
 
-subroutine update_halo(bergs)
+subroutine update_halo_icebergs(bergs)
 ! Arguments
 type(icebergs), pointer :: bergs
 ! Local variables
@@ -831,7 +831,7 @@ halo_width=bergs%grd%iceberg_halo  ! Must be less than current halo value used f
   nbergs_to_send_w=0
 
   !Bergs on eastern side of the processor
-  do grdj = grd%jsc,grd%jec ; do grdi = grd%iec+1,grd%iec+halo_width  
+  do grdj = grd%jsc,grd%jec ; do grdi = grd%iec-halo_width+1,grd%iec  
     this=>bergs%list(grdi,grdj)%first
     do while (associated(this))
         kick_the_bucket=>this
@@ -842,7 +842,7 @@ halo_width=bergs%grd%iceberg_halo  ! Must be less than current halo value used f
   enddo; enddo
 
   !Bergs on the western side of the processor
-  do grdj = grd%jsc,grd%jec ; do grdi = grd%isc-halo_width,grd%isc-1 
+  do grdj = grd%jsc,grd%jec ; do grdi = grd%isc,grd%isc+halo_width-1 
     do while (associated(this))
       kick_the_bucket=>this
       this=>this%next
@@ -913,7 +913,7 @@ halo_width=bergs%grd%iceberg_halo  ! Must be less than current halo value used f
   
 
   !Bergs on north side of the processor
-  do grdj = grd%jec-halo_width,grd%jec-1 ; do grdi = grd%isd,grd%ied
+  do grdj = grd%jec-halo_width+1,grd%jec ; do grdi = grd%isd,grd%ied
     do while (associated(this))
       kick_the_bucket=>this
       this=>this%next
@@ -924,7 +924,7 @@ halo_width=bergs%grd%iceberg_halo  ! Must be less than current halo value used f
 
 
   !Bergs on south side of the processor
-  do grdj = grd%jsc+1,grd%jsc+halo_width ; do grdi = grd%isd,grd%ied
+  do grdj = grd%jsc,grd%jsc+halo_width-1 ; do grdi = grd%isd,grd%ied
     do while (associated(this))
       kick_the_bucket=>this
       this=>this%next
@@ -1008,7 +1008,7 @@ halo_width=bergs%grd%iceberg_halo  ! Must be less than current halo value used f
   call mpp_sync_self()
 
 
-end subroutine update_halo
+end subroutine update_halo_icebergs
 
 
 

--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -1040,7 +1040,6 @@ subroutine delete_all_bergs_in_list(bergs,grdj,grdi)
     call destroy_iceberg(kick_the_bucket)
 !    call delete_iceberg_from_list(bergs%list(grdi,grdj)%first,kick_the_bucket)
   enddo
-  bergs%list(grdi,grdj)%first=>null()
 end  subroutine delete_all_bergs_in_list
 
 

--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -1039,6 +1039,7 @@ subroutine delete_all_bergs_in_list(bergs,grdj,grdi)
     this=>this%next
     call destroy_iceberg(kick_the_bucket)
 !    call delete_iceberg_from_list(bergs%list(grdi,grdj)%first,kick_the_bucket)
+    bergs%list(grdi,grdj)%first=>null()
   enddo
 end  subroutine delete_all_bergs_in_list
 

--- a/icebergs_io.F90
+++ b/icebergs_io.F90
@@ -863,6 +863,7 @@ contains
         localberg%bxn=0. !Alon
         localberg%byn=0. !Alon
         call add_new_berg_to_list(bergs%list(i,j)%first, localberg)
+        localberg%start_lon=localberg%lon-0.001
         localberg%uvel=-1.
         localberg%vvel=0.
         localberg%axn=0. !Alon
@@ -872,6 +873,7 @@ contains
         localberg%bxn=0. !Alon
         localberg%byn=0. !Alon
         call add_new_berg_to_list(bergs%list(i,j)%first, localberg)
+        localberg%start_lat=localberg%lat+0.001
         localberg%uvel=0.
         localberg%vvel=1.
         localberg%axn=0. !Alon
@@ -881,6 +883,7 @@ contains
         localberg%bxn=0. !Alon
         localberg%byn=0. !Alon
         call add_new_berg_to_list(bergs%list(i,j)%first, localberg)
+        localberg%start_lat=localberg%lat-0.001
         localberg%uvel=0.
         localberg%vvel=-1.
         localberg%axn=0. !Alon

--- a/icebergs_io.F90
+++ b/icebergs_io.F90
@@ -129,6 +129,7 @@ real, allocatable, dimension(:) :: lon,          &
                                    start_mass,   &
                                    mass_scaling, &
                                    mass_of_bits, &
+                                   halo_berg,    &
                                    heat_density
 
 integer, allocatable, dimension(:) :: ine,       &
@@ -177,6 +178,7 @@ integer :: grdi, grdj
    allocate(mass_scaling(nbergs))
    allocate(mass_of_bits(nbergs))
    allocate(heat_density(nbergs))
+   allocate(halo_berg(nbergs))
 
    allocate(ine(nbergs))
    allocate(jne(nbergs))
@@ -226,6 +228,8 @@ integer :: grdi, grdj
                                             longname='mass of bergy bits',units='kg')
   id = register_restart_field(bergs_restart,filename,'heat_density',heat_density, &
                                             longname='heat density',units='J/kg')
+  id = register_restart_field(bergs_restart,filename,'halo_berg',halo_berg, &
+                                            longname='halo_berg',units='dimensionless')
 
   ! Write variables
 
@@ -246,6 +250,7 @@ integer :: grdi, grdj
       start_lon(i) = this%start_lon; start_lat(i) = this%start_lat
       start_year(i) = this%start_year; start_day(i) = this%start_day
       start_mass(i) = this%start_mass; mass_scaling(i) = this%mass_scaling
+      halo_berg(i) = this%halo_berg 
       mass_of_bits(i) = this%mass_of_bits; heat_density(i) = this%heat_density
       this=>this%next
     enddo
@@ -277,6 +282,7 @@ integer :: grdi, grdj
              start_mass,   &
              mass_scaling, &
              mass_of_bits, &
+             halo_berg,    &
              heat_density )
 !axn, ayn, uvel_old, vvel_old, lat_old, lon_old, bxn, byn above added by Alon
 
@@ -325,7 +331,7 @@ integer :: lonid, latid,  uvelid, vvelid, ineid, jneid
 integer :: axnid, aynid, uvel_oldid, vvel_oldid, bxnid, bynid, lon_oldid, lat_oldid !Added by Alon
 integer :: massid, thicknessid, widthid, lengthid
 integer :: start_lonid, start_latid, start_yearid, start_dayid, start_massid
-integer :: scaling_id, mass_of_bits_id, heat_density_id
+integer :: scaling_id, mass_of_bits_id, heat_density_id, halo_bergid
 logical :: lres, found_restart, multiPErestart
 real :: lon0, lon1, lat0, lat1
 character(len=33) :: filename, filename_base
@@ -402,6 +408,7 @@ integer :: stderrunit
   start_dayid=inq_var(ncid, 'start_day')
   start_massid=inq_var(ncid, 'start_mass')
   scaling_id=inq_var(ncid, 'mass_scaling')
+  halo_bergid=inq_var(ncid, 'halo_berg')
   mass_of_bits_id=inq_var(ncid, 'mass_of_bits',unsafe=.true.)
   heat_density_id=inq_var(ncid, 'heat_density',unsafe=.true.)
   ineid=inq_var(ncid, 'ine',unsafe=.true.)
@@ -459,6 +466,7 @@ integer :: stderrunit
       localberg%start_day=get_double(ncid, start_dayid, k)
       localberg%start_mass=get_double(ncid, start_massid, k)
       localberg%mass_scaling=get_double(ncid, scaling_id, k)
+      localberg%halo_berg=get_double(ncid, halo_bergid, k)
       if (mass_of_bits_id>0) then ! Allow reading of older restart with no bergy bits
         localberg%mass_of_bits=get_double(ncid, mass_of_bits_id, k)
       else
@@ -546,6 +554,7 @@ contains
         localberg%start_mass=localberg%mass
         localberg%mass_scaling=bergs%mass_scaling(1)
         localberg%mass_of_bits=0.
+        localberg%halo_berg=0.
         localberg%heat_density=0.
         localberg%uvel=1.
         localberg%vvel=0.
@@ -633,6 +642,7 @@ real, allocatable, dimension(:) :: lon,          &
                                    start_mass,   &
                                    mass_scaling, &
                                    mass_of_bits, &
+                                   halo_berg,    &
                                    heat_density
 !axn, ayn, uvel_old, vvel_old, lon_old, lat_old, bxn, byn added by Alon
 integer, allocatable, dimension(:) :: ine,       &
@@ -680,6 +690,7 @@ integer, allocatable, dimension(:) :: ine,       &
      allocate(start_mass(nbergs_in_file))
      allocate(mass_scaling(nbergs_in_file))
      allocate(mass_of_bits(nbergs_in_file))
+     allocate(halo_berg(nbergs_in_file))
      allocate(heat_density(nbergs_in_file))
 
      allocate(ine(nbergs_in_file))
@@ -708,6 +719,7 @@ integer, allocatable, dimension(:) :: ine,       &
      call read_unlimited_axis(filename,'start_mass',start_mass,domain=grd%domain)
      call read_unlimited_axis(filename,'mass_scaling',mass_scaling,domain=grd%domain)
      call read_unlimited_axis(filename,'mass_of_bits',mass_of_bits,domain=grd%domain)
+     call read_unlimited_axis(filename,'halo_berg',halo_berg,domain=grd%domain)
      call read_unlimited_axis(filename,'heat_density',heat_density,domain=grd%domain)
 
      call read_unlimited_axis(filename,'ine',ine,domain=grd%domain)
@@ -765,6 +777,7 @@ integer, allocatable, dimension(:) :: ine,       &
          localberg%start_mass=start_mass(k)
          localberg%mass_scaling=mass_scaling(k)
          localberg%mass_of_bits=mass_of_bits(k)
+         localberg%halo_berg=halo_berg(k)
          localberg%heat_density=heat_density(k)
          if (really_debug) lres=is_point_in_cell(grd, localberg%lon, localberg%lat, localberg%ine, localberg%jne, explain=.true.)
          lres=pos_within_cell(grd, localberg%lon, localberg%lat, localberg%ine, localberg%jne, localberg%xi, localberg%yj)
@@ -798,6 +811,7 @@ integer, allocatable, dimension(:) :: ine,       &
                 start_mass,   &
                 mass_scaling, &
                 mass_of_bits, &
+                halo_berg,    &
                 heat_density )
 !axn, ayn, uvel_old, vvel_old, lat_old, lon_old, bxn, byn above added by Alon.
      deallocate(           &
@@ -853,6 +867,7 @@ contains
         localberg%start_mass=localberg%mass
         localberg%mass_scaling=bergs%mass_scaling(1)
         localberg%mass_of_bits=0.
+        localberg%halo_berg=0.
         localberg%heat_density=0.
         localberg%uvel=1.
         localberg%vvel=0.


### PR DESCRIPTION
 Fixed two bugs in halo_update scheme:

```
    1) Edited the delete_all_icebergs_in_list subroutine, to make it point the first pointer to null.

    2)Added a variable called halo_iceberg, which is a flag that says whether an iceberg is a temporary iceberg copied to a halo. This prevents the temporary icebergs being copied back the original processor, which causes icebergs to multiply over and over again.
```
