### PR TITLE
Rolling bergs

### DIFF
--- a/icebergs.F90
+++ b/icebergs.F90
@@ -885,7 +885,7 @@ real, parameter :: perday=1./86400.
             ! Equation 27 from Burton et al 2012, or equivolently, Weeks and Mellor 1979 with constant density
             tip_parameter=sqrt(6*(bergs%rho_bergs/rho_seawater)*(1-(bergs%rho_bergs/rho_seawater)))   !using default values gives 0.92
           endif
-          if (Tn<(tip_parameter* Wn))  then     !note that we use the Thickness instead of the Draft
+          if (Tn>(tip_parameter* Wn))  then     !note that we use the Thickness instead of the Draft
               call swap_variables(Tn,Wn)
           endif
         endif

--- a/icebergs.F90
+++ b/icebergs.F90
@@ -885,7 +885,7 @@ real, parameter :: perday=1./86400.
             ! Equation 27 from Burton et al 2012, or equivolently, Weeks and Mellor 1979 with constant density
             tip_parameter=sqrt(6*(bergs%rho_bergs/rho_seawater)*(1-(bergs%rho_bergs/rho_seawater)))   !using default values gives 0.92
           endif
-          if (Tn>(tip_parameter* Wn))  then     !note that we use the Thickness instead of the Draft
+          if ((tip_parameter*Tn)>Wn)  then     !note that we use the Thickness instead of the Draft
               call swap_variables(Tn,Wn)
           endif
         endif

--- a/icebergs.F90
+++ b/icebergs.F90
@@ -858,43 +858,38 @@ real, parameter :: perday=1./86400.
       call error_mesg('diamonds, thermodynamics', 'berg appears to have grounded!', FATAL)
     endif
 
-    ! Rolling 
+   ! Rolling 
    !There are now 3 iceberg rolling schemes:
    !1) Rolling based on aspect ratio threshold (iceberg of constant density)
    !2) Rolling based on corrected Weeks and Mellor scheme
    !3) Rolling based on incorrect Weeks and Mellor scheme - kept for legacy reasons
     Dn=(bergs%rho_bergs/rho_seawater)*Tn ! draught (keel depth)
     if ( Dn>0. ) then
-      if (bergs%use_updated_rolling_scheme) then    !Use Rolling Scheme 1
-        if (bergs%tip_parameter>0.) then
-                tip_parameter=bergs%tip_parameter
-        else
-          ! Equation 27 from Burton et al 2012, or equivolently, Weeks and Mellor 1979 with constant density
-          tip_parameter=sqrt(6*(bergs%rho_bergs/rho_seawater)*(1-(bergs%rho_bergs/rho_seawater)))   !using default values gives 0.92
-        endif
-        !print *, 'tip_parameter',tip_parameter
-        if (Tn<(tip_parameter* min(Wn,Ln)))  then     !note that we use the Thickness instead of the Draft
-          if (Wn<Ln) then
-            call swap_variables(Tn,Wn)
-          else
-            call swap_variables(Tn,Ln)
-          endif
-        endif
-      else
-        if (bergs%tip_parameter>999.) then     !Use Rolling Scheme 2
-          if ( min(Wn,Ln)<sqrt(0.92*(Tn**2)-58.32*Tn) ) then
-            if (Wn<Ln) then
-              call swap_variables(Tn,Wn)
-            else
-              call swap_variables(Tn,Ln)
-            endif
-          endif
-        else     !Use Rolling Scheme 3
+      if ( (.not.bergs%use_updated_rolling_scheme) .and. (bergs%tip_parameter<999.) ) then    !Use Rolling Scheme 3
           if ( max(Wn,Ln)<sqrt(0.92*(Dn**2)+58.32*Dn) ) then
             call swap_variables(Tn,Wn)
           endif
+      else
+        if (Wn>Ln) call swap_variables(Ln,Wn)  !Make sure that Wn is the smaller dimension
+      
+        if ( (.not.bergs%use_updated_rolling_scheme) .and. (bergs%tip_parameter>=999.) ) then    !Use Rolling Scheme 2
+          if ( Wn<sqrt(0.92*(Tn**2)-58.32*Tn) ) then
+              call swap_variables(Tn,Wn)
+          endif
         endif
-      end if
+
+        if (bergs%use_updated_rolling_scheme) then    !Use Rolling Scheme 1
+          if (bergs%tip_parameter>0.) then
+            tip_parameter=bergs%tip_parameter
+          else
+            ! Equation 27 from Burton et al 2012, or equivolently, Weeks and Mellor 1979 with constant density
+            tip_parameter=sqrt(6*(bergs%rho_bergs/rho_seawater)*(1-(bergs%rho_bergs/rho_seawater)))   !using default values gives 0.92
+          endif
+          if (Tn<(tip_parameter* Wn))  then     !note that we use the Thickness instead of the Draft
+              call swap_variables(Tn,Wn)
+          endif
+        endif
+      endif
       Dn=(bergs%rho_bergs/rho_seawater)*Tn ! re-calculate draught (keel depth) for grounding
     endif
 

--- a/icebergs.F90
+++ b/icebergs.F90
@@ -290,7 +290,7 @@ end subroutine interactive_force
 ! ##############################################################################
 
 
-subroutine accel(bergs, berg, i, j, xi, yj, lat, uvel, vvel, uvel0, vvel0, dt, ax, ay, axn, ayn, bxn, byn, debug_flag) !Saving  acceleration for Verlet, Adding Verlet flag - Alon
+subroutine accel(bergs, berg, i, j, xi, yj, lat, uvel, vvel, uvel0, vvel0, dt, ax, ay, axn, ayn, bxn, byn, debug_flag) !Saving  acceleration for Verlet, Adding Verlet flag - Alon  MP1
 !subroutine accel(bergs, berg, i, j, xi, yj, lat, uvel, vvel, uvel0, vvel0, dt, ax, ay, debug_flag) !old version commmented out by Alon
 ! Arguments
 type(icebergs), pointer :: bergs
@@ -2200,7 +2200,7 @@ lon1=berg%lon; lat1=berg%lat
   axn=berg%axn; ayn=berg%ayn !Alon
   bxn=berg%bxn; byn=berg%byn !Alon
 
-
+print *, 'first', axn, bxn, lon1, lat1, uvel1, i, j ,xi, yj
 
 ! Velocities used to update the position
   uvel2=uvel1+(dt_2*axn)+(dt_2*bxn)                    !Alon
@@ -2219,7 +2219,7 @@ if (on_tangential_plane) call rotvec_to_tang(lon1,uvel2,vvel2,xdot2,ydot2)
   endif
   dxdln=r180_pi/(Rearth*cos(latn*pi_180))
 
-! Turn the velocities into u_star, v_star.(uvel3 is v_star) - Alon (not sure how this works with tangent plane)
+! Turn the velocities into u_star, v_star.(uvel3 is v_star)
   uvel3=uvel1+(dt_2*axn)                  !Alon
   vvel3=vvel1+(dt_2*ayn)                  !Alon
 
@@ -2228,14 +2228,25 @@ if (on_tangential_plane) call rotvec_to_tang(lon1,uvel2,vvel2,xdot2,ydot2)
   i=i1;j=j1;xi=berg%xi;yj=berg%yj
   call adjust_index_and_ground(grd, lonn, latn, uvel3, vvel3, i, j, xi, yj, bounced, error_flag)  !Alon:"unclear which velocity to use here?"
 !  call adjust_index_and_ground(grd, lonn, latn, uvel1, vvel1, i, j, xi, yj, bounced, error_flag)  !Alon:"unclear which velocity to use here?"
+
+if (bounced) then  !This is the case when the iceberg changes direction due to  topography
+  axn=0.
+  ayn=0.
+  bxn=0.
+  byn=0.
+endif
+
+
   i2=i; j2=j
   if (bergs%add_weight_to_ocean .and. bergs%time_average_weight) &
     call spread_mass_across_ocean_cells(grd, i, j, xi, yj, berg%mass, berg%mass_of_bits, 0.25*berg%mass_scaling)
 
 
+print *, 'second', axn, bxn, lon1, lat1, uvel1, i , j , xi, yj
 !Calling the acceleration   (note that the velocity is converted to u_star inside the accel script)
   call accel(bergs, berg, i, j, xi, yj, latn, uvel1, vvel1, uvel1, vvel1, dt, ax1, ay1, axn, ayn, bxn, byn) !axn, ayn, bxn, byn - Added by Alon
 
+print *, 'third', axn, bxn, lon1, lat1, uvel1, i, j, xi, yj
 !Solving for the new velocity
   if (on_tangential_plane) then
     call rotvec_to_tang(lonn,uvel3,vvel3,xdot3,ydot3)
@@ -2249,6 +2260,7 @@ if (on_tangential_plane) call rotvec_to_tang(lon1,uvel2,vvel2,xdot2,ydot2)
   uveln=uvel4
   vveln=vvel4 
 
+print *, 'forth', axn, bxn, lon1, lat1, uvel1, i, j, xi, yj, uveln
 !Debugging
   if (.not.error_flag) then
     if (.not. is_point_in_cell(bergs%grd, lonn, latn, i, j)) error_flag=.true.
@@ -2299,6 +2311,7 @@ if (on_tangential_plane) call rotvec_to_tang(lon1,uvel2,vvel2,xdot2,ydot2)
   endif
 
 
+print *, 'fifth', axn, bxn, lon1, lat1, uvel1, i, j, xi, yj, uveln
 
   endif ! End of the Verlet Stepiing -added by Alon  
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/icebergs.F90
+++ b/icebergs.F90
@@ -875,33 +875,23 @@ real, parameter :: perday=1./86400.
         !print *, 'tip_parameter',tip_parameter
         if (Tn<(tip_parameter* min(Wn,Ln)))  then     !note that we use the Thickness instead of the Draft
           if (Wn<Ln) then
-            T=Tn
-            Tn=Wn
-            Wn=T
+            call swap_variables(Tn,Wn)
           else
-            T=Tn
-            Tn=Ln
-            Ln=T
+            call swap_variables(Tn,Ln)
           endif
         endif
       else
         if (bergs%tip_parameter>999.) then     !Use Rolling Scheme 2
           if ( min(Wn,Ln)<sqrt(0.92*(Tn**2)-58.32*Tn) ) then
             if (Wn<Ln) then
-              T=Tn
-              Tn=Wn
-              Wn=T
+              call swap_variables(Tn,Wn)
             else
-              T=Tn
-              Tn=Ln
-              Ln=T
+              call swap_variables(Tn,Ln)
             endif
           endif
         else     !Use Rolling Scheme 3
           if ( max(Wn,Ln)<sqrt(0.92*(Dn**2)+58.32*Dn) ) then
-            T=Tn
-            Tn=Wn
-            Wn=T
+            call swap_variables(Tn,Wn)
           endif
         endif
       end if
@@ -940,6 +930,17 @@ real, parameter :: perday=1./86400.
   
     this=>next
   enddo
+
+  contains
+
+  subroutine swap_variables(x,y)
+  ! Arguments
+  real, intent(inout) :: x, y
+  real :: temp
+  temp=x
+  x=y
+  y=temp
+  end subroutine swap_variables
 
 end subroutine thermodynamics
 

--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -182,11 +182,13 @@ type :: icebergs !; private!Niki: Ask Alistair why this is private. ice_bergs_io
   logical :: add_weight_to_ocean=.true. ! Add weight of bergs to ocean
   logical :: passive_mode=.false. ! Add weight of icebergs + bits to ocean
   logical :: time_average_weight=.false. ! Time average the weight on the ocean
+  logical :: use_updated_rolling_scheme=.false. ! Use the corrected Rolling Scheme rather than the erronios one
   logical :: Runge_not_Verlet=.True.  !True=Runge Kuttai, False=Verlet.  - Added by Alon 
   logical :: use_new_predictive_corrective =.False.  !Flag to use Bob's predictive corrective iceberg scheme- Added by Alon 
   logical :: interactive_icebergs_on=.false.  !Turn on/off interactions between icebergs  - Added by Alon 
   logical :: critical_interaction_damping_on=.true.  !Sets the damping on relative iceberg velocity to critical value - Added by Alon 
   real :: speed_limit=0. ! CFL speed limit for a berg [m/s]
+  real :: tip_parameter=0. ! parameter to override iceberg rollilng critica ratio (use zero to get parameter directly from ice and seawater densities
   real :: grounding_fraction=0. ! Fraction of water column depth at which grounding occurs
   type(buffer), pointer :: obuffer_n=>null(), ibuffer_n=>null()
   type(buffer), pointer :: obuffer_s=>null(), ibuffer_s=>null()
@@ -278,8 +280,10 @@ logical :: add_weight_to_ocean=.true. ! Add weight of icebergs + bits to ocean
 logical :: passive_mode=.false. ! Add weight of icebergs + bits to ocean
 logical :: time_average_weight=.false. ! Time average the weight on the ocean
 real :: speed_limit=0. ! CFL speed limit for a berg
+real :: tip_parameter=0. ! parameter to override iceberg rollilng critica ratio (use zero to get parameter directly from ice and seawater densities
 real :: grounding_fraction=0. ! Fraction of water column depth at which grounding occurs
 logical :: Runge_not_Verlet=.True.  !True=Runge Kutta, False=Verlet.  - Added by Alon 
+logical :: use_updated_rolling_scheme=.false. ! Use the corrected Rolling Scheme rather than the erronios one
 logical :: use_new_predictive_corrective =.False.  !Flag to use Bob's predictive corrective iceberg scheme- Added by Alon 
 logical :: interactive_icebergs_on=.false.  !Turn on/off interactions between icebergs  - Added by Alon 
 logical :: critical_interaction_damping_on=.true.  !Sets the damping on relative iceberg velocity to critical value - Added by Alon 
@@ -291,8 +295,8 @@ real, dimension(nclasses) :: mass_scaling=(/2000, 200, 50, 20, 10, 5, 2, 1, 1, 1
 real, dimension(nclasses) :: initial_thickness=(/40., 67., 133., 175., 250., 250., 250., 250., 250., 250./) ! Total thickness of newly calved bergs (m)
 namelist /icebergs_nml/ verbose, budget, halo, traj_sample_hrs, initial_mass, traj_write_hrs, &
          distribution, mass_scaling, initial_thickness, verbose_hrs, spring_coef, radial_damping_coef, tangental_damping_coef, &
-         rho_bergs, LoW_ratio, debug, really_debug, use_operator_splitting, bergy_bit_erosion_fraction, &
-         parallel_reprod, use_slow_find, sicn_shift, add_weight_to_ocean, passive_mode, ignore_ij_restart, use_new_predictive_corrective, &
+         rho_bergs, LoW_ratio, debug, really_debug, use_operator_splitting, bergy_bit_erosion_fraction, use_updated_rolling_scheme, &
+         parallel_reprod, use_slow_find, sicn_shift, add_weight_to_ocean, passive_mode, ignore_ij_restart, use_new_predictive_corrective, tip_parameter, &
          time_average_weight, generate_test_icebergs, speed_limit, fix_restart_dates, use_roundoff_fix, Runge_not_Verlet, interactive_icebergs_on, critical_interaction_damping_on, &
          old_bug_rotated_weights, make_calving_reproduce,restart_input_dir, orig_read, old_bug_bilin,do_unit_tests,grounding_fraction, input_freq_distribution, force_all_pes_traj
 
@@ -544,7 +548,9 @@ endif
   bergs%passive_mode=passive_mode
   bergs%time_average_weight=time_average_weight
   bergs%speed_limit=speed_limit
+  bergs%tip_parameter=tip_parameter
   bergs%Runge_not_Verlet=Runge_not_Verlet   !Alon
+  bergs%use_updated_rolling_scheme=use_updated_rolling_scheme  !Alon
   bergs%critical_interaction_damping_on=critical_interaction_damping_on   !Alon
   bergs%interactive_icebergs_on=interactive_icebergs_on   !Alon
   bergs%use_new_predictive_corrective=use_new_predictive_corrective  !Alon

--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -182,13 +182,13 @@ type :: icebergs !; private!Niki: Ask Alistair why this is private. ice_bergs_io
   logical :: add_weight_to_ocean=.true. ! Add weight of bergs to ocean
   logical :: passive_mode=.false. ! Add weight of icebergs + bits to ocean
   logical :: time_average_weight=.false. ! Time average the weight on the ocean
-  logical :: use_updated_rolling_scheme=.false. ! Use the corrected Rolling Scheme rather than the erronios one
+  logical :: use_updated_rolling_scheme=.false. ! True to use the aspect ratio based rolling scheme rather than incorrect version of WM scheme   (set tip_parameter=1000. for correct WM scheme)
   logical :: Runge_not_Verlet=.True.  !True=Runge Kuttai, False=Verlet.  - Added by Alon 
   logical :: use_new_predictive_corrective =.False.  !Flag to use Bob's predictive corrective iceberg scheme- Added by Alon 
   logical :: interactive_icebergs_on=.false.  !Turn on/off interactions between icebergs  - Added by Alon 
   logical :: critical_interaction_damping_on=.true.  !Sets the damping on relative iceberg velocity to critical value - Added by Alon 
   real :: speed_limit=0. ! CFL speed limit for a berg [m/s]
-  real :: tip_parameter=0. ! parameter to override iceberg rollilng critica ratio (use zero to get parameter directly from ice and seawater densities
+  real :: tip_parameter=0. ! parameter to override iceberg rollilng critica ratio (use zero to get parameter directly from ice and seawater densities) 
   real :: grounding_fraction=0. ! Fraction of water column depth at which grounding occurs
   type(buffer), pointer :: obuffer_n=>null(), ibuffer_n=>null()
   type(buffer), pointer :: obuffer_s=>null(), ibuffer_s=>null()


### PR DESCRIPTION
There were a number of bugs in the iceberg rolling scheme which was copied from Martin and Adcroft 2010, which in turn was copied from Bigg et al 1997, which came from Weeks and Mellor 1978.

A new scheme has been added where icebergs tip based on a critical aspect ratio. The new scheme is run by setting the runtime flag use_updated_rolling_scheme=True. The tip_parameter can either be set at runtime, or it set to a default value based on the iceberg density and density of sea water

When use_updated_rolling_scheme=False, the Weeks and Mellor scheme is used.
If tip_parameter>999 then a corrected version of the scheme is used.
If tip_parameter <999 then the incorrect (old scheme is used)
ed by default and the edits do not change the answers.

The model defaults to running the old incorrect scheme so that we do not change the answers.
