### PR TITLE
303 bergs cgrid memory errors

### DIFF
--- a/icebergs.F90
+++ b/icebergs.F90
@@ -35,6 +35,7 @@ use ice_bergs_framework, only: add_new_berg_to_list,delete_iceberg_from_list,des
 use ice_bergs_framework, only: grd_chksum2,grd_chksum3
 use ice_bergs_framework, only: fix_restart_dates, offset_berg_dates
 use ice_bergs_framework, only: orig_read  ! Remove when backward compatibility no longer needed
+use ice_bergs_framework, only: missing_value
 
 use ice_bergs_io,        only: ice_bergs_io_init,write_restart,write_trajectory
 use ice_bergs_io,        only: read_restart_bergs,read_restart_bergs_orig,read_restart_calving
@@ -1199,6 +1200,8 @@ integer :: stderrunit
     Jv_off = (size(tauya,2) - (grd%jec - grd%jsc))/2 - grd%jsc + 1
     allocate(uC_tmp(grd%isd:grd%ied,grd%jsd:grd%jed), &
              vC_tmp(grd%isd:grd%ied,grd%jsd:grd%jed))
+    uC_tmp(:,:) = missing_value
+    vC_tmp(:,:) = missing_value
     !   If the iceberg model used symmetric memory, the starting value of these
     ! copies would need to be decremented by 1.
     do i=grd%isc,grd%iec ; do j=grd%jsc,grd%jec

--- a/icebergs.F90
+++ b/icebergs.F90
@@ -1201,10 +1201,8 @@ integer :: stderrunit
              vC_tmp(grd%isd:grd%ied,grd%jsd:grd%jed))
     !   If the iceberg model used symmetric memory, the starting value of these
     ! copies would need to be decremented by 1.
-    do I=grd%isc,grd%iec ; do j=grd%jsc,grd%jec
-      uC_tmp(I,j) = tauxa(I+Iu_off, j+ju_off)
-    enddo ; enddo
-    do i=grd%isc,grd%iec ; do J=grd%jsc,grd%jec
+    do i=grd%isc,grd%iec ; do j=grd%jsc,grd%jec
+      uC_tmp(i,j) = tauxa(i+Iu_off, j+ju_off)
       vC_tmp(i,J) = tauya(i+iv_off, J+Jv_off)
     enddo ; enddo
 

--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -18,6 +18,7 @@ implicit none ; private
 integer, parameter :: buffer_width=28 !Changed from 20 to 28 by Alon 
 integer, parameter :: buffer_width_traj=31  !Changed from 23 by Alon
 integer, parameter :: nclasses=10 ! Number of ice bergs classes
+real, parameter :: missing_value = -1.0e34
 
 !Local Vars
 ! Global data (minimal for debugging)
@@ -45,7 +46,7 @@ logical :: force_all_pes_traj=.false. ! Force all pes write trajectory files reg
 public nclasses,buffer_width,buffer_width_traj
 public verbose, really_debug, debug, restart_input_dir,make_calving_reproduce,old_bug_bilin,use_roundoff_fix
 public ignore_ij_restart, use_slow_find,generate_test_icebergs,old_bug_rotated_weights,budget
-public orig_read, force_all_pes_traj
+public orig_read, force_all_pes_traj, missing_value
 
 
 !Public types


### PR DESCRIPTION
There is a discussion of the issue here: https://github.com/NOAA-GFDL/MOM6/issues/303

Valgrind was producing a kind of false-positive: unitialised halo data was being used but later masked. 
