### PR TITLE
Fixing counter bug

### DIFF
--- a/icebergs.F90
+++ b/icebergs.F90
@@ -1815,7 +1815,11 @@ integer :: stderrunit
           newberg%start_lon=newberg%lon
           newberg%start_lat=newberg%lat
           newberg%start_year=bergs%current_year
-          newberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i+(iNg*(j-1)))  ! unique number for each iceberg
+          if (.not. bergs%read_old_restarts) then
+            newberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i+(iNg*(j-1)))  ! unique number for each iceberg
+          else
+            newberg%iceberg_num=-1
+          endif
           newberg%start_day=bergs%current_yearday+ddt/86400.
           newberg%start_mass=bergs%initial_mass(k)
           newberg%mass_scaling=bergs%mass_scaling(k)

--- a/icebergs.F90
+++ b/icebergs.F90
@@ -1839,11 +1839,7 @@ integer :: stderrunit
           grd%stored_ice(i,j,k)=grd%stored_ice(i,j,k)-calved_to_berg
           calving_to_bergs=calving_to_bergs+calved_to_berg
           grd%real_calving(i,j,k)=grd%real_calving(i,j,k)+calved_to_berg/bergs%dt
-
-          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           ddt=ddt-bergs%dt*2./17. ! Minor offset to start day (negative offsets)
-          !ddt=ddt+bergs%dt*2./17. ! Minor offset to start day
-          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           icnt=icnt+1
           bergs%nbergs_calved=bergs%nbergs_calved+1
           bergs%nbergs_calved_by_class(k)=bergs%nbergs_calved_by_class(k)+1

--- a/icebergs.F90
+++ b/icebergs.F90
@@ -1839,7 +1839,11 @@ integer :: stderrunit
           grd%stored_ice(i,j,k)=grd%stored_ice(i,j,k)-calved_to_berg
           calving_to_bergs=calving_to_bergs+calved_to_berg
           grd%real_calving(i,j,k)=grd%real_calving(i,j,k)+calved_to_berg/bergs%dt
-          ddt=ddt+bergs%dt*2./17. ! Minor offset to start day
+
+          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+          ddt=ddt-bergs%dt*2./17. ! Minor offset to start day (negative offsets)
+          !ddt=ddt+bergs%dt*2./17. ! Minor offset to start day
+          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           icnt=icnt+1
           bergs%nbergs_calved=bergs%nbergs_calved+1
           bergs%nbergs_calved_by_class(k)=bergs%nbergs_calved_by_class(k)+1

--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -711,7 +711,6 @@ real :: current_time_val
 
   current_time_val=float(iyr)+yearday(imon, iday, ihr, imin, isec)/367.
   if (latest_start_year<=current_time_val) return ! No conflicts!
-  !if (latest_start_year<=float(iyr)+yearday(imon, iday, ihr, imin, isec)/367.) return ! No conflicts!
 
   yr_offset=int(latest_start_year+1.)-iyr
   if (mpp_pe().eq.mpp_root_pe()) write(*,'(a,i8,a)') &

--- a/icebergs_framework.F90
+++ b/icebergs_framework.F90
@@ -693,6 +693,7 @@ type(time_type), intent(in) :: Time
 type(iceberg), pointer :: this
 integer :: iyr, imon, iday, ihr, imin, isec, yr_offset
 real :: latest_start_year, berg_start_year
+real :: current_time_val
 
   call get_date(Time, iyr, imon, iday, ihr, imin, isec)
   latest_start_year=iyr-99999
@@ -708,7 +709,9 @@ real :: latest_start_year, berg_start_year
   enddo
   call mpp_max(latest_start_year)
 
-  if (latest_start_year<=float(iyr)+yearday(imon, iday, ihr, imin, isec)/367.) return ! No conflicts!
+  current_time_val=float(iyr)+yearday(imon, iday, ihr, imin, isec)/367.
+  if (latest_start_year<=current_time_val) return ! No conflicts!
+  !if (latest_start_year<=float(iyr)+yearday(imon, iday, ihr, imin, isec)/367.) return ! No conflicts!
 
   yr_offset=int(latest_start_year+1.)-iyr
   if (mpp_pe().eq.mpp_root_pe()) write(*,'(a,i8,a)') &

--- a/icebergs_io.F90
+++ b/icebergs_io.F90
@@ -298,6 +298,7 @@ integer, allocatable, dimension(:) :: ine,       &
 
   ! Write stored ice
   filename='RESTART/calving.res.nc'
+  if (verbose.and.mpp_pe().eq.mpp_root_pe()) write(stderrunit,'(2a)') 'diamonds, write_restart: writing ',filename
 
   call grd_chksum3(bergs%grd, bergs%grd%stored_ice, 'write stored_ice')
   call write_data(filename, 'stored_ice', bergs%grd%stored_ice, bergs%grd%domain)
@@ -473,11 +474,6 @@ integer :: stderrunit, iNg, jNg, i, j
       localberg%start_lat=get_double(ncid, start_latid, k)
       localberg%start_year=get_int(ncid, start_yearid, k)
       if (bergs%read_old_restarts) then
-        ! This emulates the iceberg counter used at calving sites but uses the restart position instead
-        !i = localberg%ine
-        !j = localberg%jne
-        !localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i+(iNg*(j-1)))  ! unique number for each iceberg
-        !grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         localberg%iceberg_num=-1
       else
         localberg%iceberg_num=get_int(ncid, iceberg_numid, k)
@@ -799,15 +795,7 @@ integer, allocatable, dimension(:) :: ine,       &
       localberg%start_lon=start_lon(k)
       localberg%start_lat=start_lat(k)
       localberg%start_year=start_year(k)
-      !if (bergs%read_old_restarts) then
-      !  ! This emulates the iceberg counter used at calving sites but uses the restart position instead
-      !  !i = localberg%ine
-      !  !j = localberg%jne
-      !  !localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i+(iNg*(j-1)))  ! unique number for each iceberg
-      !  !grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
-      !else
-        localberg%iceberg_num=iceberg_num(k)
-      !endif
+      localberg%iceberg_num=iceberg_num(k)
       localberg%start_day=start_day(k)
       localberg%start_mass=start_mass(k)
       localberg%mass_scaling=mass_scaling(k)
@@ -907,47 +895,34 @@ contains
         localberg%mass_scaling=bergs%mass_scaling(1)
         localberg%mass_of_bits=0.
         localberg%heat_density=0.
+        localberg%axn=0. !Alon
+        localberg%ayn=0. !Alon
+        localberg%uvel_old=0. !Alon
+        localberg%vvel_old=0. !Alon
+        localberg%bxn=0. !Alon
+        localberg%byn=0. !Alon
+
+        !Berg A
         localberg%uvel=1.
         localberg%vvel=0.
-        localberg%axn=0. !Alon
-        localberg%ayn=0. !Alon
-        localberg%uvel_old=0. !Alon
-        localberg%vvel_old=0. !Alon
-        localberg%bxn=0. !Alon
-        localberg%byn=0. !Alon
         localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
         grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
+        !Berg B
         localberg%uvel=-1.
         localberg%vvel=0.
-        localberg%axn=0. !Alon
-        localberg%ayn=0. !Alon
-        localberg%uvel_old=0. !Alon
-        localberg%vvel_old=0. !Alon
-        localberg%bxn=0. !Alon
-        localberg%byn=0. !Alon
         localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
         grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
+        !Berg C
         localberg%uvel=0.
         localberg%vvel=1.
-        localberg%axn=0. !Alon
-        localberg%ayn=0. !Alon
-        localberg%uvel_old=0. !Alon
-        localberg%vvel_old=0. !Alon
-        localberg%bxn=0. !Alon
-        localberg%byn=0. !Alon
         localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
         grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
+        !Berg D
         localberg%uvel=0.
         localberg%vvel=-1.
-        localberg%axn=0. !Alon
-        localberg%ayn=0. !Alon
-        localberg%uvel_old=0. !Alon
-        localberg%vvel_old=0. !Alon
-        localberg%bxn=0. !Alon
-        localberg%byn=0. !Alon
         localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
         grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)

--- a/icebergs_io.F90
+++ b/icebergs_io.F90
@@ -298,7 +298,6 @@ integer, allocatable, dimension(:) :: ine,       &
 
   ! Write stored ice
   filename='RESTART/calving.res.nc'
-  if (verbose.and.mpp_pe().eq.mpp_root_pe()) write(stderrunit,'(2a)') 'diamonds, write_restart: writing ',filename
 
   call grd_chksum3(bergs%grd, bergs%grd%stored_ice, 'write stored_ice')
   call write_data(filename, 'stored_ice', bergs%grd%stored_ice, bergs%grd%domain)
@@ -475,10 +474,11 @@ integer :: stderrunit, iNg, jNg, i, j
       localberg%start_year=get_int(ncid, start_yearid, k)
       if (bergs%read_old_restarts) then
         ! This emulates the iceberg counter used at calving sites but uses the restart position instead
-        i = localberg%ine
-        j = localberg%jne
-        localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i+(iNg*(j-1)))  ! unique number for each iceberg
-        grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
+        !i = localberg%ine
+        !j = localberg%jne
+        !localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i+(iNg*(j-1)))  ! unique number for each iceberg
+        !grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
+        localberg%iceberg_num=-1
       else
         localberg%iceberg_num=get_int(ncid, iceberg_numid, k)
       endif
@@ -576,47 +576,34 @@ contains
         localberg%mass_scaling=bergs%mass_scaling(1)
         localberg%mass_of_bits=0.
         localberg%heat_density=0.
+        localberg%axn=0. !Alon
+        localberg%ayn=0. !Alon
+        localberg%uvel_old=0. !Alon
+        localberg%vvel_old=0. !Alon
+        localberg%bxn=0. !Alon
+        localberg%byn=0. !Alon
+        
+        !Berg A
         localberg%uvel=1.
         localberg%vvel=0.
-        localberg%axn=0. !Alon
-        localberg%ayn=0. !Alon
-        localberg%uvel_old=0. !Alon
-        localberg%vvel_old=0. !Alon
-        localberg%bxn=0. !Alon
-        localberg%byn=0. !Alon
         localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
         grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
+        !Berg B
         localberg%uvel=-1.
         localberg%vvel=0.
-        localberg%axn=0. !Alon
-        localberg%ayn=0. !Alon
-        localberg%uvel_old=0. !Alon
-        localberg%vvel_old=0. !Alon
-        localberg%bxn=0. !Alon
-        localberg%byn=0. !Alon
         localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
         grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
+        !Berg C
         localberg%uvel=0.
         localberg%vvel=1.
-        localberg%axn=0. !Alon
-        localberg%ayn=0. !Alon
-        localberg%uvel_old=0. !Alon
-        localberg%vvel_old=0. !Alon
-        localberg%bxn=0. !Alon
-        localberg%byn=0. !Alon
         localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
         grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
+        !Berg D
         localberg%uvel=0.
         localberg%vvel=-1.
-        localberg%axn=0. !Alon
-        localberg%ayn=0. !Alon
-        localberg%uvel_old=0. !Alon
-        localberg%vvel_old=0. !Alon
-        localberg%bxn=0. !Alon
-        localberg%byn=0. !Alon
         localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i +(iNg*(j-1)))  ! unique number for each iceberg
         grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
         call add_new_berg_to_list(bergs%first, localberg)
@@ -812,15 +799,15 @@ integer, allocatable, dimension(:) :: ine,       &
       localberg%start_lon=start_lon(k)
       localberg%start_lat=start_lat(k)
       localberg%start_year=start_year(k)
-      if (bergs%read_old_restarts) then
-        ! This emulates the iceberg counter used at calving sites but uses the restart position instead
-        i = localberg%ine
-        j = localberg%jne
-        localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i+(iNg*(j-1)))  ! unique number for each iceberg
-        grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
-      else
+      !if (bergs%read_old_restarts) then
+      !  ! This emulates the iceberg counter used at calving sites but uses the restart position instead
+      !  !i = localberg%ine
+      !  !j = localberg%jne
+      !  !localberg%iceberg_num=((iNg*jNg)*grd%iceberg_counter_grd(i,j))+(i+(iNg*(j-1)))  ! unique number for each iceberg
+      !  !grd%iceberg_counter_grd(i,j)=grd%iceberg_counter_grd(i,j)+1
+      !else
         localberg%iceberg_num=iceberg_num(k)
-      endif
+      !endif
       localberg%start_day=start_day(k)
       localberg%start_mass=start_mass(k)
       localberg%mass_scaling=mass_scaling(k)
@@ -1013,7 +1000,7 @@ type(randomNumberStream) :: rns
     else
       if (verbose.and.mpp_pe().eq.mpp_root_pe()) write(*,'(a)') &
      'diamonds, read_restart_calving: iceberg_counter_grd WAS NOT FOUND in the file. Setting to 0.'
-      grd%iceberg_counter_grd(:,:)=0
+      grd%iceberg_counter_grd(:,:)=1
     endif
     bergs%restarted=.true.
   else


### PR DESCRIPTION
2 bugs have been fixed:

1) The code was not reproducing across restarts because of the iceberg_num and the counter when the read_old_restart flag was true. This has been resolved by setting iceberg_num=-1 when the read_old_restart flag is true.

2) The code was not reproducing across restarts because of start_year in certain situations. This is because a small positive offset was being added to the start_year of certain icebergs. This meant that sometimes a restart file was being created with icebergs with start dates in the future. If the fix_restart_dates restart date flag was set to true, then these "future bergs" would lead to the start date being changed, which would prevent the code from reproducing across restarts.
This problem is resolved by using negative offsets.

3) The code as been refactored slightly in the read_restart subroutine where generating icebergs for testing. Redundant lines have been removed
