### PR TITLE
Fix for when restart files have zero bergs

### DIFF
--- a/icebergs_io.F90
+++ b/icebergs_io.F90
@@ -800,7 +800,7 @@ integer, allocatable, dimension(:) :: ine,       &
      allocate(iceberg_num(nbergs_in_file))
   endif
 
-  if (found_restart) then
+  if (found_restart .and. nbergs_in_file > 0) then
      call read_unlimited_axis(filename,'lon',lon,domain=grd%domain)
      call read_unlimited_axis(filename,'lat',lat,domain=grd%domain)
      call read_unlimited_axis(filename,'uvel',uvel,domain=grd%domain)


### PR DESCRIPTION
- When the restart file exists but has zero length data in then
  the model was correctly NOT allocating but was then proceeding to
  try and read into the non-allocated array. This avoids that condition.
- I thought this was fixed before but apparently not.

@nikizadehgfdl Apparently all our restart tests now have at one berg in every file? Can you test then handle this? Thx.