### PR TITLE
Fix  double append of _ensNN to restart filenames in ensemble runs

### DIFF
--- a/icebergs_io.F90
+++ b/icebergs_io.F90
@@ -201,7 +201,7 @@ integer :: grdi, grdj
    allocate(id_ij(nbergs))
 
 
-  call get_instance_filename("icebergs.res.nc", filename)
+  filename = trim("icebergs.res.nc")
   call set_domain(bergs%grd%domain)
   call register_restart_axis(bergs_restart,filename,'i',nbergs)
   call set_meta_global(bergs_restart,'file_format_major_version',ival=(/file_format_major_version/))


### PR DESCRIPTION
- Fixes issue #10
- Restart tests for ensemble runs fail because the icebergs restart file names from each ensemble member has the ensemble_id appended twice like
icebergs.res.ens_01.ens_01.nc instead of
icebergs.res.ens_01.nc
and so they are ignored when the model restarts.