### PR TITLE
Add timestamp to intermediate iceberg restart files.

### DIFF
--- a/icebergs.F90
+++ b/icebergs.F90
@@ -5161,16 +5161,17 @@ subroutine icebergs_stock_pe(bergs, index, value)
 end subroutine icebergs_stock_pe
 
 !> Write restart files
-subroutine icebergs_save_restart(bergs)
+subroutine icebergs_save_restart(bergs, time_stamp)
   ! Arguments
   type(icebergs), pointer :: bergs !< Container for all types and memory
+  character(len=*),    intent(in), optional :: time_stamp !< Timestamp for restart file
   ! Local variables
 
   if (.not.associated(bergs)) return
 
   call mpp_clock_begin(bergs%clock_iow)
   call bergs_chksum(bergs, 'write_restart bergs')
-  call write_restart(bergs)
+  call write_restart(bergs, time_stamp)
   call mpp_clock_end(bergs%clock_iow)
 
 end subroutine icebergs_save_restart

--- a/icebergs_io.F90
+++ b/icebergs_io.F90
@@ -101,9 +101,11 @@ integer :: stdlogunit, stderrunit
 end subroutine ice_bergs_io_init
 
 !> Write an iceberg restart file
-subroutine write_restart(bergs)
+subroutine write_restart(bergs, time_stamp)
 ! Arguments
 type(icebergs), pointer :: bergs !< Icebergs container
+character(len=*), intent(in), optional :: time_stamp !< Timestamp for restart file
+
 ! Local variables
 type(bond), pointer :: current_bond
 integer :: i,j,id
@@ -201,7 +203,7 @@ integer :: grdi, grdj
    allocate(id_ij(nbergs))
 
 
-  call get_instance_filename("icebergs.res.nc", filename)
+  filename = "icebergs.res.nc"
   call set_domain(bergs%grd%domain)
   call register_restart_axis(bergs_restart,filename,'i',nbergs)
   call set_meta_global(bergs_restart,'file_format_major_version',ival=(/file_format_major_version/))
@@ -287,7 +289,7 @@ integer :: grdi, grdj
   enddo ; enddo
 
 
-  call save_restart(bergs_restart)
+  call save_restart(bergs_restart, time_stamp)
   call free_restart_type(bergs_restart)
 
   deallocate(              &


### PR DESCRIPTION
Also corrects double tagging of ensemble name to iceberg restart filename.
