### PR TITLE
Fix type ambiguity for buffer

### DIFF
--- a/src/icebergs.F90
+++ b/src/icebergs.F90
@@ -55,7 +55,7 @@ use ice_bergs_framework, only: set_constant_interaction_length_and_width, skip_f
 use ice_bergs_framework, only: break_bonds_on_sub_steps
 use ice_bergs_framework, only: short_step_mts_grounding, radius_based_drag
 
-use ice_bergs_io,        only: ice_bergs_io_init, write_restart, write_trajectory, write_bond_trajectory
+use ice_bergs_io,        only: ice_bergs_io_init, write_restart_bergs, write_trajectory, write_bond_trajectory
 use ice_bergs_io,        only: read_restart_bergs, read_restart_calving
 use ice_bergs_io,        only: read_restart_bonds
 use ice_bergs_io,        only: read_ocean_depth
@@ -8142,7 +8142,7 @@ subroutine icebergs_save_restart(bergs, time_stamp)
 
   call mpp_clock_begin(bergs%clock_iow)
   call bergs_chksum(bergs, 'write_restart bergs')
-  call write_restart(bergs, time_stamp)
+  call write_restart_bergs(bergs, time_stamp)
   call mpp_clock_end(bergs%clock_iow)
 
 end subroutine icebergs_save_restart

--- a/src/icebergs_fms2io.F90
+++ b/src/icebergs_fms2io.F90
@@ -16,7 +16,7 @@ use mpp_mod, only: mpp_get_current_pelist
 use fms_mod, only: stdlog, stderr, error_mesg, FATAL, WARNING, NOTE, lowercase
 
 use fms2_io_mod, only: get_instance_filename
-use fms2_io_mod, only: FmsNetcdfDomainFile_t, open_file, close_file, read_restart, fms2_io_write_restart => write_restart
+use fms2_io_mod, only: FmsNetcdfDomainFile_t, open_file, close_file, read_restart, write_restart
 use fms2_io_mod, only: variable_exists, get_dimension_size, get_num_dimensions, get_dimension_names
 use fms2_io_mod, only: get_variable_attribute, variable_att_exists, write_data, read_data
 use fms2_io_mod, only: register_unlimited_compressed_axis, register_axis, register_restart_field, register_variable_attribute
@@ -57,7 +57,7 @@ implicit none ; private
 include 'netcdf.inc'
 
 public ice_bergs_io_init
-public read_restart_bergs, write_restart, write_trajectory, write_bond_trajectory
+public read_restart_bergs, write_restart_bergs, write_trajectory, write_bond_trajectory
 public read_restart_calving, read_restart_bonds
 public read_ocean_depth
 
@@ -121,7 +121,7 @@ integer :: stdlogunit, stderrunit
 end subroutine ice_bergs_io_init
 
 !> Write an iceberg restart file
-subroutine write_restart(bergs, time_stamp)
+subroutine write_restart_bergs(bergs, time_stamp)
 ! Arguments
 type(icebergs), pointer :: bergs !< Icebergs container
 character(len=*), intent(in), optional :: time_stamp !< Timestamp for restart file
@@ -408,7 +408,7 @@ character(len=1), dimension(1) :: dim_names_1d
                                      dim_names_1d,longname='static_berg',units='dimensionless')
 
   call register_field(fileobj, "i", "int")
-  call fms2_io_write_restart(fileobj)
+  call write_restart(fileobj)
 
   call get_dimension_size(fileobj, "i", global_nbergs)
   call write_data(fileobj, "i", global_nbergs)
@@ -562,7 +562,7 @@ character(len=1), dimension(1) :: dim_names_1d
                                      dim_names_1d,longname='broken status',units='none')
   endif
 
-  call fms2_io_write_restart(fileobj)
+  call write_restart(fileobj)
   call close_file(fileobj)
 
   deallocate(first_id_cnt,          &
@@ -626,10 +626,10 @@ character(len=1), dimension(1) :: dim_names_1d
   endif
 
   call write_axis_metadata(fileobj)
-  call fms2_io_write_restart(fileobj)
+  call write_restart(fileobj)
   call write_axis_data(fileobj, size(bergs%grd%stored_ice, 3))
   call close_file(fileobj)
-end subroutine write_restart
+end subroutine write_restart_bergs
 
 !> Find the last berg in a linked list.
 function last_berg(berg)

--- a/src/icebergs_fms2io.F90
+++ b/src/icebergs_fms2io.F90
@@ -2727,7 +2727,7 @@ subroutine register_axis_wrapper(fileobj)
     integer :: dim_size             !< Size of the dimension
     integer :: ndims                !< Number of dimensions in the file
     logical :: is_domain_decomposed !< Flag indication if domain decomposed
-    character(len=1) :: buffer      !< string buffer
+    character(len=1) :: cbuffer      !< string buffer
 
     ndims = get_num_dimensions(fileobj)
     allocate(file_dim_names(ndims))
@@ -2744,21 +2744,21 @@ subroutine register_axis_wrapper(fileobj)
 
           !< If the variable exists look for the "cartesian_axis" or "axis" variable attribute
           if (variable_att_exists(fileobj, file_dim_names(i), "axis")) then
-              call get_variable_attribute(fileobj, file_dim_names(i), "axis", buffer)
+              call get_variable_attribute(fileobj, file_dim_names(i), "axis", cbuffer)
 
               !< If the attribute exists and it is "x" or "y" register it as a domain decomposed dimension
-              if (lowercase(buffer) .eq. "x" .or. lowercase(buffer) .eq. "y" ) then
+              if (lowercase(cbuffer) .eq. "x" .or. lowercase(cbuffer) .eq. "y" ) then
                   is_domain_decomposed = .true.
-                  call register_axis(fileobj, file_dim_names(i), buffer)
+                  call register_axis(fileobj, file_dim_names(i), cbuffer)
               endif
 
           else if (variable_att_exists(fileobj, file_dim_names(i), "cartesian_axis")) then
-              call get_variable_attribute(fileobj, file_dim_names(i), "cartesian_axis", buffer)
+              call get_variable_attribute(fileobj, file_dim_names(i), "cartesian_axis", cbuffer)
 
               !< If the attribute exists and it "x" or "y" register it as a domain decomposed dimension
-              if (lowercase(buffer) .eq. "x" .or. lowercase(buffer) .eq. "y" ) then
+              if (lowercase(cbuffer) .eq. "x" .or. lowercase(cbuffer) .eq. "y" ) then
                   is_domain_decomposed = .true.
-                  call register_axis(fileobj, file_dim_names(i), buffer)
+                  call register_axis(fileobj, file_dim_names(i), cbuffer)
               endif
 
           endif !< If variable attribute exists

--- a/src/icebergs_fmsio.F90
+++ b/src/icebergs_fmsio.F90
@@ -54,7 +54,7 @@ implicit none ; private
 include 'netcdf.inc'
 
 public ice_bergs_io_init
-public read_restart_bergs, write_restart, write_trajectory, write_bond_trajectory
+public read_restart_bergs, write_restart_bergs, write_trajectory, write_bond_trajectory
 public read_restart_calving, read_restart_bonds
 public read_ocean_depth
 
@@ -112,7 +112,7 @@ integer :: stdlogunit, stderrunit
 end subroutine ice_bergs_io_init
 
 !> Write an iceberg restart file
-subroutine write_restart(bergs, time_stamp)
+subroutine write_restart_bergs(bergs, time_stamp)
 ! Arguments
 type(icebergs), pointer :: bergs !< Icebergs container
 character(len=*), intent(in), optional :: time_stamp !< Timestamp for restart file
@@ -552,7 +552,7 @@ integer :: grdi, grdj
 
   ! Write stored ice
   filename='calving.res.nc'
-  if (verbose.and.mpp_pe().eq.mpp_root_pe()) write(stderrunit,'(2a)') 'KID, write_restart: writing ',filename
+  if (verbose.and.mpp_pe().eq.mpp_root_pe()) write(stderrunit,'(2a)') 'KID, write_restart_bergs: writing ',filename
   call grd_chksum3(bergs%grd, bergs%grd%stored_ice, 'write stored_ice')
   call grd_chksum2(bergs%grd, bergs%grd%stored_heat, 'write stored_heat')
   if (bergs%tau_calving>0.) then
@@ -572,7 +572,7 @@ integer :: grdi, grdj
   call save_restart(calving_restart, time_stamp)
   call free_restart_type(calving_restart)
 
-end subroutine write_restart
+end subroutine write_restart_bergs
 
 !> Find the last berg in a linked list.
 function last_berg(berg)


### PR DESCRIPTION
Fixes some compiler compatibility issues (which arise from ambiguity in the code):
- gnu compiler was complaining about "buffer" being a derived type (it was a local variable but also a module subroutine)
- nVidia compiler was complaining about write_restart because it was both a renamed subroutine from another module and a local subroutine

I've checked this compiles and runs in both FMS1 mode and FMS2 with 2023.01 tag (although the AM2-based coupled models cannot be tested because they do not compile with FMS2).